### PR TITLE
IBX-8471: Prepared dependencies for future Symfony 7 upgrade

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+    push:
+        branches:
+            - main
+            - '[0-9]+.[0-9]+'
+    pull_request: ~
+
+jobs:
+    tests:
+        name: Tests
+        runs-on: "ubuntu-latest"
+        timeout-minutes: 10
+
+        strategy:
+            fail-fast: false
+            matrix:
+                php:
+                    - '8.3'
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup PHP Action
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  coverage: none
+                  extensions: pdo_sqlite, gd
+                  tools: cs2pr
+
+            - uses: ramsey/composer-install@v3
+              with:
+                  dependency-versions: "highest"
+                  composer-options: "${{ matrix.composer_options }}"
+
+            - name: Setup problem matchers for PHPUnit
+              run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+            - name: Run test suite
+              run: ./vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Composer
 vendor/*
 composer.lock
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
         "hautelook/templated-uri-bundle": "self.version"
     },
     "require": {
-        "php": "^5.4|^7.0|^8.0",
-        "symfony/framework-bundle": "^2.8.50 || ^3.4.26 || ^4.1.12 || ^4.2.7 || ^5.0",
-        "ibexa/templated-uri-router": "^2.0|^3.0"
+        "php": ">=8.3",
+        "symfony/framework-bundle": "^6.0 || ^7.0",
+        "ibexa/templated-uri-router": "^4.0.x-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.36 || ^5.6.3 || ^6.0 || ^7.0"
+        "phpunit/phpunit": "^9.6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,10 @@
         "phpunit/phpunit": "^4.8.36 || ^5.6.3 || ^6.0 || ^7.0"
     },
     "autoload": {
-        "psr-0": { "Hautelook\\TemplatedUriBundle": "" }
+        "psr-4": {
+            "Hautelook\\TemplatedUriBundle\\": ""
+        }
     },
-    "target-dir": "Hautelook/TemplatedUriBundle",
     "extra": {
         "branch-alias": {
             "dev-main": "4.0.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "ibexa/templated-uri-bundle",
-    "description": "Fork of hautelook/templated-uri-bundle. Symfony2 Bundle that provides a RFC-6570 compatible router and URL Generator.",
-    "keywords": ["Symfony2", "URI", "URL", "RFC 6570", "JSON", "XML", "Hateoas"],
+    "description": "Fork of hautelook/templated-uri-bundle. Symfony Bundle that provides a RFC-6570 compatible router and URL Generator.",
+    "keywords": ["Symfony", "URI", "URL", "RFC 6570", "JSON", "XML", "Hateoas"],
     "type": "symfony-bundle",
     "license": "MIT",
     "homepage": "http://www.hautelooktech.com/",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="Tests/bootstrap.php">
-    <testsuites>
-        <testsuite name="HautelookTemplatedUriBundle Test Suite">
-            <directory>./Tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./vendor</directory>
-                <directory>./Tests</directory>
-                <directory>./Resources</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="Tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+      <directory>./Tests</directory>
+      <directory>./Resources</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="HautelookTemplatedUriBundle Test Suite">
+      <directory>./Tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
| :ticket: Issue | IBX-8471 |
|----------------|--------------------------|


#### Related PRs: 
- https://github.com/ibexa/templated-uri-router/pull/6


#### Description:

This is preparation for Symfony 7 upgrade (another PR). Temporarily I've allowed Symfony `^6.0 || ^7.0` to see if everything is working.

Unlike in the case of ibexa/templated-uri-router#6, syncing this fork with the upstream doesn't make sense as there are no changes to the code. In the past we've narrowed down Composer dependencies due to GHSA-pjj2-77xr-wwr7 and that's the only difference with the upstream.

Trivia: Seems `goetas/TemplatedUriBundle` repository (`hautelook/templated-uri-bundle` Composer package)  is not installable with `hautelook/templated-uri-router` version `^4` as the former one can be installed only on PHP ^7 due to old PHPUnit dependency while the latter one requires PHP >=8.0.2.

##### TODO
- [x] Provide GHA running PHPUnit test


#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
