### PR TITLE
IBX-8471: Upgraded codebase to Symfony 7

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,21 +15,8 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder('hautelook_templated_uri');
-
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            // BC for symfony/config <= 4.1
-            $rootNode = $treeBuilder->root('hautelook_templated_uri');
-        }
-
-        // Here you should define the parameters that are allowed to
-        // configure your bundle. See the documentation linked above for
-        // more information on that topic.
-
-        return $treeBuilder;
+        return new TreeBuilder('hautelook_templated_uri');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ibexa/templated-uri-router": "^4.0.x-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6"
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": ">=8.3",
-        "symfony/framework-bundle": "^6.0 || ^7.0",
+        "symfony/framework-bundle": "^7.0",
         "ibexa/templated-uri-router": "^4.0.x-dev"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="Tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="Tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+  <testsuites>
+    <testsuite name="HautelookTemplatedUriBundle Test Suite">
+      <directory>./Tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
     <include>
       <directory>./</directory>
     </include>
@@ -9,10 +14,5 @@
       <directory>./Tests</directory>
       <directory>./Resources</directory>
     </exclude>
-  </coverage>
-  <testsuites>
-    <testsuite name="HautelookTemplatedUriBundle Test Suite">
-      <directory>./Tests</directory>
-    </testsuite>
-  </testsuites>
+  </source>
 </phpunit>


### PR DESCRIPTION
> [!CAUTION]
> - [x] Merge #2 first
> - [x] Merge ibexa/templated-uri-router#7 first
> - [x] Make sure TMP commit is dropped

| :ticket: Issue | IBX-8471 |
|----------------|-----------|

#### Related PRs:

- https://github.com/ibexa/templated-uri-bundle/pull/2
- https://github.com/ibexa/templated-uri-router/pull/7

#### Description:

This is a fork of [`goetas/TemplatedUriRouter`](https://github.com/goetas/TemplatedUriRouter). I'll propose similar PR for the upstream at later time.

Upgrading Symfony dependencies to version 7 along with necessary codebase changes.

Key changes:
- [x] [Composer] Dropped symfony/framework-bundle requirement allowing ^6.0
- [x] [Tests] Bumped PHPUnit to ^10.5 and migrated its configuration
- [x] Upgraded Bundle Configuration class to Symfony 7

#### For QA:

Sanity tests and/or regression builds.
