### PR TITLE
Replaced internal HttpKernel Extension usage in HautelookTemplatedUriExtension

### DIFF
--- a/DependencyInjection/HautelookTemplatedUriExtension.php
+++ b/DependencyInjection/HautelookTemplatedUriExtension.php
@@ -4,7 +4,7 @@ namespace Hautelook\TemplatedUriBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
 /**


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

#### Description:
This PR updates HautelookTemplatedUriExtension to stop using the internal Symfony\Component\HttpKernel\DependencyInjection\Extension class, which has been marked as internal since Symfony 7.1 and is planned for deprecation in 8.1.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
