### PR TITLE
Added `void` return type to HautelookTemplatedUriExtension::load()

### DIFF
--- a/DependencyInjection/HautelookTemplatedUriExtension.php
+++ b/DependencyInjection/HautelookTemplatedUriExtension.php
@@ -14,10 +14,7 @@ use Symfony\Component\DependencyInjection\Loader;
  */
 class HautelookTemplatedUriExtension extends Extension
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|

#### Description:
This PR updates the load() method in HautelookTemplatedUriExtension to explicitly declare the void return type.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
